### PR TITLE
Don't throw syntax error when attempting to add unsupported rule for current browser

### DIFF
--- a/src/attach.js
+++ b/src/attach.js
@@ -32,7 +32,11 @@ const buildRule = (s, classname) => {
 
 export const attachRule = (rule, sheet) => {
   if (typeof document === 'undefined') { return; }
-  sheet.insertRule(rule, sheet.cssRules.length);
+  try {
+    sheet.insertRule(rule, sheet.cssRules.length);
+  } catch (e) {
+    console.warn('Vudu: Failed to insert rule:', rule, e);
+  }
 };
 
 


### PR DESCRIPTION
We just hit this - on Internet Explorer & Edge, adding the `::placeholder` rule throws a syntax error.

It was really really hard to debug, so I think it would be better to do `console.warn` rather than let the browser throw!